### PR TITLE
Add missing "var" declaration

### DIFF
--- a/src/convex.js
+++ b/src/convex.js
@@ -29,8 +29,8 @@ function _lowerTangent(pointset) {
 
 // pointset has to be sorted by X
 function convex(pointset) {
-    var convex;
-    upper = _upperTangent(pointset);
+    var convex,
+    upper = _upperTangent(pointset),
     lower = _lowerTangent(pointset);
     convex = lower.concat(upper);
     convex.push(pointset[0]);  


### PR DESCRIPTION
Missing "var" can produce: ReferenceError: upper is not defined
