### PR TITLE
replaced Array.prototype.push.apply to avoid hitting stack size limit

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -33,7 +33,11 @@ Grid.prototype = {
 
         for (let x = tlCellX; x <= brCellX; x++) {
             for (let y = tlCellY; y <= brCellY; y++) {
-                Array.prototype.push.apply(points, this.cellPoints(x, y));
+
+                // replaced Array.prototype.push.apply to avoid hitting stack size limit on larger arrays.
+                for(let i = 0; i < this.cellPoints(x, y).length; i++){
+                    points.push(this.cellPoints(x, y)[i]);
+                }
             }
         }
 


### PR DESCRIPTION
when using the packages with large arrays node.js will error with a max stack-size reached. similar to [this](https://stackoverflow.com/questions/61740599/rangeerror-maximum-call-stack-size-exceeded-with-array-push) issue. It was caused by using push.apply or push(...[]) in grid.js. Currently solved this by pushing the items on by one. 