### PR TITLE
Prevent non distribution files in the tarball pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "type": "git",
         "url": "git://github.com/AndriiHeonia/hull.git"
     },
-    "main": "./src/hull.js",
+    "main": "./dist/hull.js",
     "devDependencies": {
         "nodemon": "~1.18.0",
         "mocha": "~6.0.2",
@@ -31,5 +31,8 @@
         "node": true,
         "esversion": 6
     },
-    "license": "BSD"
+    "license": "BSD",
+    "files": [
+        "dist"
+    ]
 }


### PR DESCRIPTION
Package size on npm is currently 17MB due to large files. Such files are not needed to be packed for the distribution package, that will make the package hugely smaller, making it a tiny dependency with logs of aggregated value.

Please check the documentation and the proposed changes in the following link:
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files